### PR TITLE
Sub-template rendering

### DIFF
--- a/src/Context/HelperContext.php
+++ b/src/Context/HelperContext.php
@@ -107,7 +107,7 @@ class HelperContext implements ContextInterface
      * @param mixed[] $variables Template data
      * @return string            Rendered template
      */
-    public function include(string $file_path, array $variables): string
+    public function include(string $file_path, array $variables = []): string
     {
         if (empty($this->stack)) {
             throw new TemplateIncludeException($this);

--- a/src/Exception/TemplateIncludeException.php
+++ b/src/Exception/TemplateIncludeException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Swiftly\Template\Exception;
+
+use RuntimeException;
+use Swiftly\Template\ContextInterface;
+
+use function sprintf;
+use function get_class;
+
+/**
+ * Exception thrown when calling include from a non-template context
+ */
+class TemplateIncludeException extends RuntimeException
+{
+    public function __construct(ContextInterface $context)
+    {
+        parent::__construct(
+            'Method %s::include() can only be called from within templates',
+            get_class($context)
+        );
+    }
+}

--- a/src/Exception/TemplateIncludeException.php
+++ b/src/Exception/TemplateIncludeException.php
@@ -16,8 +16,10 @@ class TemplateIncludeException extends RuntimeException
     public function __construct(ContextInterface $context)
     {
         parent::__construct(
-            'Method %s::include() can only be called from within templates',
-            get_class($context)
+            sprintf(
+                'Method %s::include() can only be called from within templates',
+                get_class($context)
+            )
         );
     }
 }

--- a/tests/Context/HelperContextTest.php
+++ b/tests/Context/HelperContextTest.php
@@ -7,6 +7,7 @@ use Swiftly\Template\Context\HelperContext;
 use Swiftly\Template\Escape\HtmlEscaper;
 use Swiftly\Template\Escape\JsonEscaper;
 use Swiftly\Template\EscapeInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Swiftly\Template\Exception\MissingTemplateException;
 use Swiftly\Template\Exception\TemplateIncludeException;
 use Swiftly\Template\Exception\UnknownSchemeException;
@@ -123,8 +124,8 @@ Class HelperContextTest Extends TestCase
             'scheme' => get_class( $scheme )
         ]);
 
+        /** @var MockObject&HelperContext $escaper */
         $escaper = $context->escape( 'scheme', 'some_content' );
-
         $escaper->expects( $this->once() )
             ->method( '__toString' )
             ->willReturn( 'some_content' );

--- a/tests/templates/example/include-parent.php
+++ b/tests/templates/example/include-parent.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Used by the HelperContext::testCanIncludeTemplateInParentDirectory test to
+ * verify that we can include templates located in parent directories
+ *
+ * @package Swiftly\Template\Tests
+ * 
+ * @var Swiftly\Template\Context\HelperContext $this
+ * @var string $name
+ */
+?>
+<?php echo $this->include('../simple.php', ['name' => $name]);

--- a/tests/templates/example/simple.php
+++ b/tests/templates/example/simple.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Used by the HelperContext::testCanIncludeTemplateFromTemplate test to verify
+ * include functionality
+ *
+ * @package Swiftly\Template\Tests
+ *
+ * @var Swiftly\Template\Context\HelperContext $this
+ * @var string $name
+ */
+?>
+<?php echo $name; ?> says hello from the sub directory<?php

--- a/tests/templates/include-child.php
+++ b/tests/templates/include-child.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Used by the HelperContext::testCanIncludeTemplateInSubDirectory test to
+ * verify that we can include templates located in child directories
+ *
+ * @package Swiftly\Template\Tests
+ *
+ * @var Swiftly\Template\Context\HelperContext $this
+ * @var string $name
+ */
+?>
+<?php echo $this->include('./example/simple.php', ['name' => $name]);

--- a/tests/templates/include-exception.php
+++ b/tests/templates/include-exception.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Used by the HelperContext::testThrowsOnMissingTemplate test to verify that
+ * attempting to include non-existant templates will cause an exception
+ *
+ * @package Swiftly\Template\Tests
+ * 
+ * @var Swiftly\Template\Context\HelperContext $this
+ */
+?>
+<?php echo $this->include('./no-template.php');

--- a/tests/templates/include-same.php
+++ b/tests/templates/include-same.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Used by the HelperContext::testCanIncludeTemplateInSameDirectory test to
+ * verify that we can include templates located in the same directory
+ *
+ * @package Swiftly\Template\Tests
+ *
+ * @var Swiftly\Template\Context\HelperContext $this
+ * @var string $name
+ */
+?>
+<?php echo $this->include('./simple.php', ['name' => $name]);


### PR DESCRIPTION
Provided ability for templates rendered with a `HelperContext` to load sub-templates with a new `include()` method. Additionally, added a `TemplateIncludeException` which is thrown when the method is called incorrectly/from the wrong scope.